### PR TITLE
Add more context to timeout error from hackney adapter

### DIFF
--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -33,7 +33,7 @@ if Code.ensure_loaded?(:hackney) do
         {:ok, %{env | status: status, headers: format_headers(headers), body: format_body(body)}}
       else
         {:error, :timeout} ->
-          {:error, {:timeout, %{env | status: nil, headers: nil, body: nil}}}
+          {:error, {:timeout, env}}
 
         error ->
           error

--- a/lib/tesla/adapter/hackney.ex
+++ b/lib/tesla/adapter/hackney.ex
@@ -31,6 +31,12 @@ if Code.ensure_loaded?(:hackney) do
     def call(env, opts) do
       with {:ok, status, headers, body} <- request(env, opts) do
         {:ok, %{env | status: status, headers: format_headers(headers), body: format_body(body)}}
+      else
+        {:error, :timeout} ->
+          {:error, {:timeout, %{env | status: nil, headers: nil, body: nil}}}
+
+        error ->
+          error
       end
     end
 

--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -22,8 +22,8 @@ defmodule Tesla.Adapter.HackneyTest do
     assert {:error, {:timeout, %Env{} = response}} = call(request, recv_timeout: 1000)
     assert response.url == "#{@http}/delay/2"
     assert is_nil(response.status)
-    assert is_nil(response.headers)
     assert is_nil(response.body)
+    assert Enum.empty?(response.headers)
   end
 
   test "get with `with_body: true` option" do

--- a/test/tesla/adapter/hackney_test.exs
+++ b/test/tesla/adapter/hackney_test.exs
@@ -13,6 +13,19 @@ defmodule Tesla.Adapter.HackneyTest do
 
   alias Tesla.Env
 
+  test "timeout get request" do
+    request = %Env{
+      method: :get,
+      url: "#{@http}/delay/2"
+    }
+
+    assert {:error, {:timeout, %Env{} = response}} = call(request, recv_timeout: 1000)
+    assert response.url == "#{@http}/delay/2"
+    assert is_nil(response.status)
+    assert is_nil(response.headers)
+    assert is_nil(response.body)
+  end
+
   test "get with `with_body: true` option" do
     request = %Env{
       method: :get,


### PR DESCRIPTION
When there's a timeout in the hackney adapter (caused by hackney), instead of returning `{:error, :timeout}` we actually want to return the full `%Env{}` so that we know what caused the timeout. This is pretty important when we want to send an event to telemetry to keep track of response time.

NOTE: My goal is to create a PR on the main repository but it probably won't go in the next release since it's a breaking change so in the meantime it goes into our fork !